### PR TITLE
Fix estimate_similarity_transformation_test.cc 

### DIFF
--- a/src/gdls_star/estimate_similarity_transformation_test.cc
+++ b/src/gdls_star/estimate_similarity_transformation_test.cc
@@ -112,9 +112,10 @@ class EstimateSimilarityTransformationTest : public ::testing::Test {
                                             const double max_angle_deg) {
     CHECK_LT(min_angle_deg, max_angle_deg);
     std::uniform_real_distribution<double> angle_dist(min_angle_deg,
-                                                      max_angle_deg);    
+                                                      max_angle_deg);
+    std::mt19937& prng = *rng;    
     const Eigen::Quaterniond rotation(
-        Eigen::AngleAxisd(DegToRad(35.0),
+        Eigen::AngleAxisd(DegToRad(angle_dist(prng)),
                           Eigen::Vector3d::Random().normalized()));
     return rotation;
   }


### PR DESCRIPTION
Fix estimate_similarity_transformation_test.cc  as it was using a fixed angle in GenerateRandomRotation() function.